### PR TITLE
Avoid showing Tealium config as the first option on system configuration page

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <tab id="tealium" translate="label" sortOrder="10">
+        <tab id="tealium" translate="label" sortOrder="450">
             <label>Tealium</label>
         </tab>
         <section id="tealium_tags" translate="label" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
currently shows up like this:
![image](https://user-images.githubusercontent.com/4903365/85839005-ad62c780-b79a-11ea-9619-eba4f8b83fcb.png)
